### PR TITLE
Add the highlighter class for use with markmon

### DIFF
--- a/buttondown.css
+++ b/buttondown.css
@@ -552,3 +552,19 @@ div.footnotes > hr:after
     {
     text-align: left;
     }
+
+
+/* ---- Markmon ---- */
+
+/* This is the class that markmon uses for that bar to indicate where the
+   last change happened. Here we replicate the definition from markmon own
+   css so that we can use buttondown.css with markmon without 'losing' the
+   bar to indicate the last change */
+.highlighter
+{
+    position: absolute;
+    border-bottom: 2px solid orangered;
+    left: 2%;
+    width: 96%;
+    box-shadow: 0 1px 1px white;
+}


### PR DESCRIPTION
When writing markdown a very useful program is [markmon](https://github.com/yyjhao/markmon). Since I'll use your nice buttondown css with pandoc in the finished document anyway I prefer to also use it when working in the document. This commit just add the highlighter class definition from markmon own cssm so that I don't use the nice red line that markmon uses to indicate where the last change happened.

The markmon command to use buttondown.css is something similar to
`markmon --command "pandoc any_pandoc_options" --stylesheet buttondown.css`
